### PR TITLE
Don't print Purchase Request Alerts for a NullUser.

### DIFF
--- a/app/views/purchases/new.html.erb
+++ b/app/views/purchases/new.html.erb
@@ -1,4 +1,4 @@
-<%- unless @pending_purchases.blank? -%>
+<%- unless current_user.id or @pending_purchases.blank? -%>
   <div class="alert">
     <button type="button" class="close" data-dismiss="alert">&times;</button>
     You currently have <%= pluralize @pending_purchases.length, "pending purchase" %>.  Please <%= link_to("review them", find_user_path(current_user.id, received: "f")) %> before ordering any additional equipment.


### PR DESCRIPTION
A NullUser shouldn't really exist at this point in all reality, but in case it does, don't try and print out pending purchase request alerts.
